### PR TITLE
Update ethereum-ledger-go dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.46.2-0.20220831122102-a95c62680975
 	github.com/ethereum/go-ethereum v1.10.19
-	github.com/evmos/ethereum-ledger-go v0.1.1
+	github.com/evmos/ethereum-ledger-go v0.1.2
 	github.com/evmos/ethermint v0.6.1-0.20220919141022-34226aa7b1fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.10.19 h1:EOR5JbL4MD5yeOqv8W2iC1s4NximrTjqFccUz8lyBRA=
 github.com/ethereum/go-ethereum v1.10.19/go.mod h1:IJBNMtzKcNHPtllYihy6BL2IgK1u+32JriaTbdt4v+w=
-github.com/evmos/ethereum-ledger-go v0.1.1 h1:EVBidKt1xHjvZ9kIyKFy9/FfLE737OL4ZuyrjnK7GSQ=
-github.com/evmos/ethereum-ledger-go v0.1.1/go.mod h1:azPpikO/CFtDlIfJB2lBcodgtRr6miidSCBI/u+mxzk=
+github.com/evmos/ethereum-ledger-go v0.1.2 h1:FkCUvkJS8eMkj9v9imsv7i2AcyqqesCYPeIDCPwdNeE=
+github.com/evmos/ethereum-ledger-go v0.1.2/go.mod h1:azPpikO/CFtDlIfJB2lBcodgtRr6miidSCBI/u+mxzk=
 github.com/evmos/ethermint v0.6.1-0.20220919141022-34226aa7b1fa h1:bpvKBR28IiB5XccRBih6zHK6p83YAddhVuovuVbtfJg=
 github.com/evmos/ethermint v0.6.1-0.20220919141022-34226aa7b1fa/go.mod h1:BMNkMffNTcrpv/kG52aZtHBnQpeiVyX5+Gr3tlt3Faw=
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=


### PR DESCRIPTION
Includes fix to add compatibility for Ledger Nano S Plus devices.